### PR TITLE
Fix Generic Tool Animations & Update Primitive Sword in Project File

### DIFF
--- a/Neolithic.csproj
+++ b/Neolithic.csproj
@@ -348,11 +348,11 @@
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\hoe.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\javelin.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\knife.json" />
-    <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\primitive-sword.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\shovel.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\sickle.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\slaughteringaxe.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\spear-primitive.json" />
+    <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\neolithic\sword.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\pickaxe.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\prospectingpick.json" />
     <None Include="bin\TheNeolithicMod\assets\game\itemtypes\tool\saw.json" />

--- a/bin/TheNeolithicMod/assets/game/itemtypes/tool/hoe.json
+++ b/bin/TheNeolithicMod/assets/game/itemtypes/tool/hoe.json
@@ -11,7 +11,8 @@
 	],
 	damagedby: ["blockbreaking", "attacking"],
 	shape: { base: "item/tool/hoe" },
-	heldTpHitAnimation: "breaktool",
+  heldTpHitAnimation: "breaktool",
+  heldTpUseAnimation: "hoe",
 	textures: {
 		"metal": { base: "block/metal/ingot/{metal}" },
 		"wood": { base: "item/tool/material/wood" } 

--- a/bin/TheNeolithicMod/assets/game/itemtypes/tool/neolithic/hoe.json
+++ b/bin/TheNeolithicMod/assets/game/itemtypes/tool/neolithic/hoe.json
@@ -12,7 +12,8 @@
 		{ code: "cordage", states: ["rope", "sinew", "leatherstrips", ] },
 	],
 	damagedby: ["blockbreaking", "attacking"],
-	heldTpHitAnimation: "breaktool",
+  heldTpHitAnimation: "breaktool",
+  heldTpUseAnimation: "hoe",
 	shapeByType: {
 		"*-bone-*": {base: "item/tool/bone-hoe"},
 		"*": {base: "item/tool/branch-hoe" },

--- a/bin/TheNeolithicMod/assets/game/itemtypes/tool/neolithic/javelin.json
+++ b/bin/TheNeolithicMod/assets/game/itemtypes/tool/neolithic/javelin.json
@@ -15,7 +15,7 @@
 		],
 	drawtype: "json",
 	shape: { base: "item/tool/primitive-javelin" },
-	heldTpHitAnimation: "breaktool",
+	heldTpHitAnimation: "spearhit",
 	MaxStackSize: 32,
 	textures: {
 		"bone": { base: "block/bone" },

--- a/bin/TheNeolithicMod/assets/game/itemtypes/tool/neolithic/shovel.json
+++ b/bin/TheNeolithicMod/assets/game/itemtypes/tool/neolithic/shovel.json
@@ -12,7 +12,7 @@
 	],
 	tool: "shovel",
 	damagedby: ["blockbreaking", "attacking"],
-	heldTpHitAnimation: "breaktool",
+	heldTpHitAnimation: "shoveldig",
 	shapeByType: {
 		"*-bone-*": {base: "item/tool/bone-shovel"},
 		"*": {base: "item/tool/branch-shovel" },


### PR DESCRIPTION
Noticed that a couple of Neolithic tools used a generic "breaktool" hit animation instead of the specialized vanilla ones. Also utilized the vanilla "hoe" animation for right-clicking with hoes.

Also noticed that the "Neolithic.csproj" file had a reference to a "primitive-sword.json" file that doesn't exist anymore. So, I replaced it with the currently existing "sword.json" file that was never added to the project.