### PR TITLE
Logwall Fixes

### DIFF
--- a/bin/TheNeolithicMod/assets/neolithicmod/blocktypes/wood/logwall/logwall.json
+++ b/bin/TheNeolithicMod/assets/neolithicmod/blocktypes/wood/logwall/logwall.json
@@ -64,28 +64,15 @@
 		},
 	collisionselectionboxesbytype: {
 		"*-wall-*": [
-			{ x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.5, z2: 1,
-			rotateXByType: {
-				"*-up-east": 0,
-				"*-left-east": 90,
-				"*-down-east": 180,
-				"*-right-east": 270,
-				"*-up-west": 0,
-				"*-left-west": 90,
-				"*-down-west": 180,
-				"*-right-west": 270,
-			},
-			rotateZByType: {
-				"*-up-north": 0,
-				"*-left-north": 270,
-				"*-down-north": 180,
-				"*-right-north": 90,
-				"*-up-south": 0,
-				"*-left-south": 270,
-				"*-down-south": 180,
-				"*-right-south": 90,
-			}
-			}
+			{ x1: 0, y1: 0, z1: 0, x2: 1, y2: 1, z2: 0.5625,
+        "rotateX": 0,
+        "rotateYByType": {
+          "*-north": 0,
+          "*-west": 90,
+          "*-south": 180,
+          "*-east": 270
+        }
+      }
 		],
 		"*-jut-*": [
 			{ x1: 0, y1: 0, z1: 0.45, x2: 1, y2: 1, z2: 1,
@@ -106,22 +93,32 @@
 			},
 		],
 		"*-corner-*": [
-			{ x1: 0, y1: 0, z1: 0, x2: 0.55, y2: 1, z2: 0.45,
+			{ x1: 0, y1: 0, z1: 0, x2: 1, y2: 1, z2: 0.5625,
 			rotateYByType: {
-					"*-north": 180,
-					"*-east": 90,
-					"*-south": 0,
-					"*-west": 270,
+					"*-north": 0,
+					"*-west": 90,
+					"*-south": 180,
+					"*-east": 270,
 				}
 			},
-			{ x1: 0, y1: 0, z1: 0.45, x2: 1, y2: 1, z2: 1,
+			{ x1: 0.4375, y1: 0, z1: 0.5625, x2: 1, y2: 1, z2: 1,
 			rotateYByType: {
-					"*-north": 180,
-					"*-east": 90,
-					"*-south": 0,
-					"*-west": 270,
-				}
-			}
+					"*-north": 0,
+					"*-west": 90,
+					"*-south": 180,
+					"*-east": 270,
+				},
+       rotateZByType: {
+          "*-up-*": 0,
+          "*-right-north": 90,
+          "*-right-east": 90,
+          "*-right-*": 270,
+          "*-down-*": 180,
+          "*-left-south*": 90,
+          "*-left-west": 90,
+          "*-left-*": 270
+       }
+      }
 		]
 	},
 	replaceable: 100,

--- a/bin/TheNeolithicMod/assets/neolithicmod/blocktypes/wood/logwall/logwall.json
+++ b/bin/TheNeolithicMod/assets/neolithicmod/blocktypes/wood/logwall/logwall.json
@@ -14,10 +14,10 @@
 	],
 	attributes: {
 		handbook: {
-			groupBy: ["logwall-*"]
+			groupBy: ["logwall-*-up-north"]
 		},
 	},
-	creativeinventory: { "general": ["*-up-*-north"], "construction": ["*-up-*"], "neolithicblocks": ["*-up-*"] },
+	creativeinventory: { "general": ["*-up-north"], "construction": ["*-up-north"], "neolithicblocks": ["*-up-north"] },
 		variantgroups: [
 		{ code: "type", states: ["wall", "corner", "jut"]},
 		{ loadFromProperties: "block/wood" },

--- a/bin/TheNeolithicMod/assets/neolithicmod/blocktypes/wood/logwall/logwall.json
+++ b/bin/TheNeolithicMod/assets/neolithicmod/blocktypes/wood/logwall/logwall.json
@@ -62,7 +62,10 @@
 		"logwall-corner-*": { all: true},
 		"logwall-jut-*": { all: true},
 		},
-	collisionselectionboxesbytype: {
+  drops: [
+    { code: "logwall-{type}-{wood}-{style}-up-north" }
+  ],
+  collisionselectionboxesbytype: {
 		"*-wall-*": [
 			{ x1: 0, y1: 0, z1: 0, x2: 1, y2: 1, z2: 0.5625,
         "rotateX": 0,


### PR DESCRIPTION
Fixed some things for the Logwall blocks:

- collision/selection boxes now match the orientations correctly
- only the "*-up-north" variant will be dropped to prevent inventory clutter
- logwalls only show as there "*-up-north" variant to prevent creative inventory clutter.