### PR TITLE
Fix Bunch O' Tallow Candle Placing

### DIFF
--- a/bin/TheNeolithicMod/assets/game/itemtypes/resource/candle.json
+++ b/bin/TheNeolithicMod/assets/game/itemtypes/resource/candle.json
@@ -4,17 +4,36 @@
 		{ code:"metal", states: ["wax", "tallow", ] },
 	],
 	class: "ItemCandle",
-	attributes: {
-		blockfirstcodepart: "bunchocandles",
-		isCandle: true,
-		handbook:{ 
-				groupBy: ["candle-*"],
-				extraSections: [
-					{ title: "handbook-item-sources", text:"To make candles you need to make a <a href=\"handbook://block-candlemold-copper-plain\">metal candle mold</a> , Place sisal twine for candle wick on the mold, and then pour smelted fat for tallow candles or bees wax for wax candles." }
-					]
+  attributesByType: {
+    "candle-wax": {
+      "blockfirstcodepart": "bunchocandles",
+      "isCandle": true,
+      "handbook": {
+        "groupBy": [ "candle-wax" ],
+        "extraSections": [
+          {
+            "title": "handbook-item-sources",
+            "text": "To make candles you need to make a <a href=\"handbook://block-candlemold-copper-plain\">metal candle mold</a> , Place sisal twine for candle wick on the mold, and then pour smelted fat for tallow candles or bees wax for wax candles."
+          }
+        ]
 
-		},
-	},
+      }
+    },
+    "candle-tallow": {
+      "blockfirstcodepart": "bunchotallowcandles",
+      "isCandle": true,
+      "handbook": {
+        "groupBy": [ "candle-tallow" ],
+        "extraSections": [
+          {
+            "title": "handbook-item-sources",
+            "text": "To make candles you need to make a <a href=\"handbook://block-candlemold-copper-plain\">metal candle mold</a> , Place sisal twine for candle wick on the mold, and then pour smelted fat for tallow candles or bees wax for wax candles."
+          }
+        ]
+
+      }
+    }
+  },
 	maxstacksize: 32,
 	shapeByType: {
 		"candle-wax": { base: "block/wax/candle3" },


### PR DESCRIPTION
Tallow candles now correctly place a "bunchotallowcandles" block instead of a normal "bunchocandles" block.

This allows for unique properties between the two types of candles and also prevents an exploit where a player could place tallow candles as a "bunchocandles" and then break that bunch to receive normal wax candles.