### PR TITLE
Fixed Hoe Texture

### DIFF
--- a/bin/TheNeolithicMod/assets/game/itemtypes/tool/hoe.json
+++ b/bin/TheNeolithicMod/assets/game/itemtypes/tool/hoe.json
@@ -14,7 +14,7 @@
   heldTpHitAnimation: "breaktool",
   heldTpUseAnimation: "hoe",
 	textures: {
-		"metal": { base: "block/metal/ingot/{metal}" },
+		"material": { base: "item/tool/material/{metal}" },
 		"wood": { base: "item/tool/material/wood" } 
 	},
 	tool: "hoe",


### PR DESCRIPTION
Fixed hoe tool texture.

Vanilla hoe shape seemingly updated texture identifier to "material" instead of "metal".

Set texture to match Vanilla's special tool material as opposed to the ingot texture.